### PR TITLE
fix(#26): skip sandbox PR comments for non-PR runs

### DIFF
--- a/aws/buildspecs/sandbox-crm/deploy.yml
+++ b/aws/buildspecs/sandbox-crm/deploy.yml
@@ -36,11 +36,12 @@ phases:
           COMMENT_BODY="The deployment process for the sandbox has started.
           Please wait until the latest version is ready"
 
-          . "${CODEBUILD_SRC_DIR}/aws/scripts/sh/gh_auth_login.sh"
-
-          if ! gh pr comment "$PR_NUMBER" -R "$GITHUB_REPOSITORY" --body "$COMMENT_BODY"; then
-            echo "Failed to add comment to PR"
-            exit 1
+          if . "${CODEBUILD_SRC_DIR}/aws/scripts/sh/gh_auth_login.sh"; then
+            if ! gh pr comment "$PR_NUMBER" -R "$GITHUB_REPOSITORY" --body "$COMMENT_BODY"; then
+              echo "Failed to add start comment to PR, continuing deployment."
+            fi
+          else
+            echo "GitHub authentication failed - skipping start comment."
           fi
         fi
         echo "#### Build Project"

--- a/aws/scripts/sh/sandbox_creation.sh
+++ b/aws/scripts/sh/sandbox_creation.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+if [ -z "${PROJECT_NAME:-}" ] || [ -z "${BRANCH_NAME:-}" ] || [ -z "${AWS_DEFAULT_REGION:-}" ]; then
+    echo "Error: PROJECT_NAME, BRANCH_NAME, and AWS_DEFAULT_REGION must be set."
+    exit 1
+fi
+
 echo "Checking if bucket $PROJECT_NAME-$BRANCH_NAME exists..."
 
 if aws s3api head-bucket --bucket "$PROJECT_NAME-$BRANCH_NAME" 2>/dev/null; then


### PR DESCRIPTION
## Description
Fix the sandbox CRM deploy flow so non-PR executions skip GitHub PR comments instead of failing before the actual build and S3 deploy.

## Related Issue
Closes #26

## Motivation and Context
`sandbox-crm-creation` should support both PR-driven sandboxes and non-PR smoke executions. The current deploy buildspec always runs `gh pr comment`, which breaks non-PR runs with `PR_NUMBER=0` before the website build starts.

## How Has This Been Tested?
- Local YAML parse of `aws/buildspecs/sandbox-crm/deploy.yml`
- AWS test account reproduction of the failure on `main`
- Follow-up test and prod pipeline reruns after this branch is deployed

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).
