### PR TITLE
fix: restore CRM CloudFront staging

### DIFF
--- a/terraform/app/stacks/ci-cd-infrastructure-crm/tfvars/prod.tfvars
+++ b/terraform/app/stacks/ci-cd-infrastructure-crm/tfvars/prod.tfvars
@@ -28,7 +28,7 @@ s3_logs_lifecycle_configuration = {
 cloudwatch_log_group_retention_days = 1
 
 enable_cloudwatch_alarms  = false
-enable_cloudfront_staging = false
+enable_cloudfront_staging = true
 
 ci_cd_infra_stage_input = [
   { name = "validate", category = "Test", owner = "AWS", provider = "CodeBuild", input_artifacts = ["SourceOutput"], output_artifacts = "ValidateOutput" },

--- a/terraform/app/stacks/ci-cd-infrastructure-crm/tfvars/test.tfvars
+++ b/terraform/app/stacks/ci-cd-infrastructure-crm/tfvars/test.tfvars
@@ -28,7 +28,7 @@ s3_logs_lifecycle_configuration = {
 cloudwatch_log_group_retention_days = 1
 
 enable_cloudwatch_alarms  = false
-enable_cloudfront_staging = false
+enable_cloudfront_staging = true
 
 ci_cd_infra_stage_input = [
   { name = "validate", category = "Test", owner = "AWS", provider = "CodeBuild", input_artifacts = ["SourceOutput"], output_artifacts = "ValidateOutput" },

--- a/terraform/app/stacks/crm/tfvars/test.tfvars
+++ b/terraform/app/stacks/crm/tfvars/test.tfvars
@@ -52,4 +52,4 @@ enable_cloudwatch_alarms  = false
 enable_access_logging     = false
 enable_waf                = false
 enable_canary             = false
-enable_cloudfront_staging = false
+enable_cloudfront_staging = true


### PR DESCRIPTION
## Description
- restore CloudFront staging for the CRM test stack
- restore CloudFront staging for the CRM test CI/CD stack
- restore CloudFront staging for the CRM prod CI/CD stack
- keep the other artifact/log retention and alarm cost cuts intact

## Related Issue
- Closes #40

## Motivation and Context
The recent CRM cost-cut configuration disabled CloudFront staging in places where it changes deployment behavior more than it reduces cost. The retention and alarm reductions should remain, but the staging deployment path should be preserved.

## How Has This Been Tested?
- verified the exact tfvars diff only restores `enable_cloudfront_staging = true`
- verified `git diff --check` is clean
- full local Terraspace/Terraform validation was not possible in this shell because the required tools are not installed

## Screenshots (if appropriate)
- not applicable

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).
