### PR TITLE
fix: validate CRM shared infra stacks sequentially

### DIFF
--- a/task/terraform_tests_ci_cd_infrastructure_crm.yml
+++ b/task/terraform_tests_ci_cd_infrastructure_crm.yml
@@ -7,8 +7,14 @@ tasks:
       TS_TERRAFORM_BIN: terraform
       TS_VERSION_CHECK: "0"
     cmds:
-      - make terraspace-ci-cd-infra-init
-      - make terraspace-ci-cd-infra-validate
+      - make terraspace-init stack=ci-cd-infrastructure-crm
+      - make terraspace-validate stack=ci-cd-infrastructure-crm
+      - make terraspace-init stack=ci-cd-iam
+      - make terraspace-validate stack=ci-cd-iam
+      - make terraspace-init stack=crm-iam
+      - make terraspace-validate stack=crm-iam
+      - make terraspace-init stack=iam-groups
+      - make terraspace-validate stack=iam-groups
     silent: false
 
   format:


### PR DESCRIPTION
## Description
- align CRM shared-infra validation with the working website sequence
- run `terraspace init` immediately before `terraspace validate` for each stack
- avoid validating later stacks against stale or uninitialized Terraspace/Terraform state

## Related Issue
- closes #42

## Motivation and Context
The merged prod run failed in `ci-cd-infra-crm-prod-pipeline` execution `edb3153e-cb50-4004-ad36-f5a2a110f576`. CloudWatch logs show `ci-cd-iam` hitting Terraform `Module not installed` during validate even though the job had already completed the shared init loop. The website repo uses a stack-by-stack init/validate sequence and does not show this failure mode.

## How Has This Been Tested?
- inspected the failed AWS prod build `ci-cd-infra-crm-prod-validate:ff5b1636-216b-4b30-8db3-adbe19456e49` through AWS MCP
- compared the CRM validate task with the working website validate task
- ran `git diff --check`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).
