### PR TITLE
fix: deploy CRM sandboxes from PR branch

### DIFF
--- a/terraform/app/stacks/ci-cd-infrastructure-crm/locals.tf
+++ b/terraform/app/stacks/ci-cd-infrastructure-crm/locals.tf
@@ -300,7 +300,7 @@ locals {
             "NODEJS_VERSION"            = var.runtime_versions.nodejs,
             "BUCKET_NAME"               = var.bucket_name,
             "BRANCH_NAME"               = var.BRANCH_NAME,
-            "CRM_GIT_REPOSITORY_BRANCH" = var.crm_repo_branch,
+            "CRM_GIT_REPOSITORY_BRANCH" = var.BRANCH_NAME,
             "CRM_GIT_REPOSITORY_LINK"   = "https://github.com/${var.source_repo_owner}/${var.crm_content_repo_name}",
           }
         )


### PR DESCRIPTION
## Description

Fix the CRM sandbox deploy project so it clones and builds the CRM app from the triggering PR branch instead of always using `main`.

## Related Issue

- Closes #44

## Motivation and Context

Website sandboxes already deploy the PR branch. CRM sandboxes were only using the PR branch for sandbox naming while still cloning the CRM app from `main`, which made the sandbox content inconsistent with the triggering pull request.

## How Has This Been Tested?

- `git diff --check`
- compared website and CRM sandbox wiring to confirm the intended behavior
- AWS validation planned on the PR head commit in both test and prod shared infra pipelines, followed by sandbox creation checks in both accounts

## Screenshots (if appropriate)

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).
