### PR TITLE
fix: use runtime branch for CRM sandbox checkout

### DIFF
--- a/aws/scripts/sh/sandbox_installation.sh
+++ b/aws/scripts/sh/sandbox_installation.sh
@@ -5,9 +5,7 @@ echo #### Install Software
 : "${CRM_GIT_REPOSITORY_LINK:?Repository link is not set}"
 : "${BRANCH_NAME:?Branch name is not set}"
 
-CRM_GIT_REPOSITORY_BRANCH="${CRM_GIT_REPOSITORY_BRANCH:-main}"
-
-git clone -b "$CRM_GIT_REPOSITORY_BRANCH" "$CRM_GIT_REPOSITORY_LINK.git" /codebuild-user/crm || {
+git clone -b "$BRANCH_NAME" "$CRM_GIT_REPOSITORY_LINK.git" /codebuild-user/crm || {
     echo "Error: Failed to clone repository" >&2
     exit 1
 }

--- a/terraform/app/stacks/ci-cd-infrastructure-crm/locals.tf
+++ b/terraform/app/stacks/ci-cd-infrastructure-crm/locals.tf
@@ -300,7 +300,6 @@ locals {
             "NODEJS_VERSION"            = var.runtime_versions.nodejs,
             "BUCKET_NAME"               = var.bucket_name,
             "BRANCH_NAME"               = var.BRANCH_NAME,
-            "CRM_GIT_REPOSITORY_BRANCH" = var.BRANCH_NAME,
             "CRM_GIT_REPOSITORY_LINK"   = "https://github.com/${var.source_repo_owner}/${var.crm_content_repo_name}",
           }
         )

--- a/terraform/app/stacks/ci-cd-infrastructure-crm/locals.tf
+++ b/terraform/app/stacks/ci-cd-infrastructure-crm/locals.tf
@@ -296,11 +296,11 @@ locals {
         env_variables = merge(
           local.common_sandbox_env_variables,
           {
-            "CI"                        = "1",
-            "NODEJS_VERSION"            = var.runtime_versions.nodejs,
-            "BUCKET_NAME"               = var.bucket_name,
-            "BRANCH_NAME"               = var.BRANCH_NAME,
-            "CRM_GIT_REPOSITORY_LINK"   = "https://github.com/${var.source_repo_owner}/${var.crm_content_repo_name}",
+            "CI"                      = "1",
+            "NODEJS_VERSION"          = var.runtime_versions.nodejs,
+            "BUCKET_NAME"             = var.bucket_name,
+            "BRANCH_NAME"             = var.BRANCH_NAME,
+            "CRM_GIT_REPOSITORY_LINK" = "https://github.com/${var.source_repo_owner}/${var.crm_content_repo_name}",
           }
         )
       },

--- a/terraform/app/stacks/ci-cd-infrastructure-crm/locals.tf
+++ b/terraform/app/stacks/ci-cd-infrastructure-crm/locals.tf
@@ -296,6 +296,8 @@ locals {
         env_variables = merge(
           local.common_sandbox_env_variables,
           {
+            # CodePipeline overrides BRANCH_NAME per execution; this project-level default stays inert.
+            "BRANCH_NAME"             = var.BRANCH_NAME,
             "CI"                      = "1",
             "NODEJS_VERSION"          = var.runtime_versions.nodejs,
             "BUCKET_NAME"             = var.bucket_name,

--- a/terraform/app/stacks/ci-cd-infrastructure-crm/locals.tf
+++ b/terraform/app/stacks/ci-cd-infrastructure-crm/locals.tf
@@ -299,7 +299,6 @@ locals {
             "CI"                      = "1",
             "NODEJS_VERSION"          = var.runtime_versions.nodejs,
             "BUCKET_NAME"             = var.bucket_name,
-            "BRANCH_NAME"             = var.BRANCH_NAME,
             "CRM_GIT_REPOSITORY_LINK" = "https://github.com/${var.source_repo_owner}/${var.crm_content_repo_name}",
           }
         )


### PR DESCRIPTION
## Description

Use the runtime `BRANCH_NAME` injected by CodePipeline when cloning the CRM repo during sandbox deploys, and remove the now-misleading sandbox-only `CRM_GIT_REPOSITORY_BRANCH` env wiring.

## Related Issue

- Closes #50

## Motivation and Context

Issue #44 / PR #45 rewired the sandbox deploy project to set `CRM_GIT_REPOSITORY_BRANCH` from `var.BRANCH_NAME`, but the actual sandbox install script still cloned from that static CodeBuild project variable. During PR sandbox runs, the bucket and PR metadata followed the runtime branch while the checkout could still resolve to an older/default branch baked into the project configuration.

This change makes the sandbox install step consume the same runtime `BRANCH_NAME` that CodePipeline passes into the execution, which matches how the sandbox URL and bucket are derived.

## How Has This Been Tested?

- `bash -n aws/scripts/sh/sandbox_installation.sh`
- `git diff --check`
- verified the sandbox deploy path no longer references `CRM_GIT_REPOSITORY_BRANCH` after the checkout step
- unable to run Terraform formatting locally because `terraform` is not installed in this environment

## Screenshots (if appropriate)

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).
